### PR TITLE
Correct a typo in "Occurrence" word

### DIFF
--- a/SchedulerBot/SchedulerBot.Business.Commands/AddCommand.cs
+++ b/SchedulerBot/SchedulerBot.Business.Commands/AddCommand.cs
@@ -149,7 +149,7 @@ namespace SchedulerBot.Business.Commands
 			return new ScheduledMessageEvent
 			{
 				CreatedOn = DateTime.UtcNow,
-				NextOccurence = schedule.GetNextOccurence(),
+				NextOccurrence = schedule.GetNextOccurrence(),
 				State = ScheduledMessageEventState.Pending
 			};
 		}

--- a/SchedulerBot/SchedulerBot.Business.Commands/NextCommand.cs
+++ b/SchedulerBot/SchedulerBot.Business.Commands/NextCommand.cs
@@ -144,7 +144,7 @@ namespace SchedulerBot.Business.Commands
 			ScheduledMessageEvent nextEvent = message
 				.Events
 				.Where(@event => @event.State == ScheduledMessageEventState.Pending)
-				.OrderBy(@event => @event.NextOccurence)
+				.OrderBy(@event => @event.NextOccurrence)
 				.FirstOrDefault();
 			CommandExecutionResult executionResult = nextEvent != null
 				? ExecuteWithMessageAndCount(nextEvent.ScheduledMessage, defaultMessageCount, clientCulture)
@@ -168,11 +168,11 @@ namespace SchedulerBot.Business.Commands
 				if (hasPendingEvents)
 				{
 					ISchedule schedule = scheduleParser.Parse(message.Schedule, message.Details.TimeZoneOffset);
-					IEnumerable<DateTime> messageOccurences = schedule
-						.GetNextOccurences(DateTime.UtcNow, DateTime.MaxValue)
+					IEnumerable<DateTime> messageOccurrences = schedule
+						.GetNextOccurrences(DateTime.UtcNow, DateTime.MaxValue)
 						.Take(count);
 
-					executionResult = BuildResponseMessageText(message, messageOccurences, clientCulture);
+					executionResult = BuildResponseMessageText(message, messageOccurrences, clientCulture);
 				}
 				else
 				{
@@ -199,7 +199,7 @@ namespace SchedulerBot.Business.Commands
 					@event.State == ScheduledMessageEventState.Pending &&
 					@event.ScheduledMessage.State == ScheduledMessageState.Active &&
 					@event.ScheduledMessage.Details.ConversationId.Equals(conversationId, StringComparison.Ordinal))
-				.OrderBy(@event => @event.NextOccurence)
+				.OrderBy(@event => @event.NextOccurrence)
 				.FirstOrDefault();
 		}
 
@@ -220,7 +220,7 @@ namespace SchedulerBot.Business.Commands
 			return count > 0 && count <= maxMessageCount;
 		}
 
-		private static string BuildResponseMessageText(ScheduledMessage message, IEnumerable<DateTime> nextOccurences, CultureInfo clientCulture)
+		private static string BuildResponseMessageText(ScheduledMessage message, IEnumerable<DateTime> nextOccurrences, CultureInfo clientCulture)
 		{
 			StringBuilder stringBuilder = new StringBuilder();
 			TimeSpan timeZoneOffset = message.Details.TimeZoneOffset.GetValueOrDefault();
@@ -233,13 +233,13 @@ namespace SchedulerBot.Business.Commands
 				.Append(newLine)
 				.Append("Occurrences:");
 
-			foreach (DateTime occurence in nextOccurences)
+			foreach (DateTime occurrence in nextOccurrences)
 			{
-				DateTime adjustedOccurence = occurence.Add(timeZoneOffset);
+				DateTime adjustedOccurrence = occurrence.Add(timeZoneOffset);
 
 				stringBuilder
 					.Append(newLine)
-					.Append(adjustedOccurence.ToString(clientCulture));
+					.Append(adjustedOccurrence.ToString(clientCulture));
 			}
 
 			return stringBuilder.ToString().Trim();

--- a/SchedulerBot/SchedulerBot.Business.Services/ScheduledMessageProcessorService.cs
+++ b/SchedulerBot/SchedulerBot.Business.Services/ScheduledMessageProcessorService.cs
@@ -167,7 +167,7 @@ namespace SchedulerBot.Business.Services
 
 			return context
 				.ScheduledMessageEvents
-				.Where(@event => @event.State == ScheduledMessageEventState.Pending && @event.NextOccurence < currentTime)
+				.Where(@event => @event.State == ScheduledMessageEventState.Pending && @event.NextOccurrence < currentTime)
 				.Include(@event => @event.ScheduledMessage)
 				.ThenInclude(message => message.Details)
 				.ThenInclude(details => details.DetailsServiceUrls)
@@ -195,7 +195,7 @@ namespace SchedulerBot.Business.Services
 			scheduledMessage.Events.Add(new ScheduledMessageEvent
 			{
 				CreatedOn = DateTime.UtcNow,
-				NextOccurence = schedule.GetNextOccurence(),
+				NextOccurrence = schedule.GetNextOccurrence(),
 				State = ScheduledMessageEventState.Pending
 			});
 		}

--- a/SchedulerBot/SchedulerBot.Database.Core/Migrations/20180420113221_OccurrenceTypo.Designer.cs
+++ b/SchedulerBot/SchedulerBot.Database.Core/Migrations/20180420113221_OccurrenceTypo.Designer.cs
@@ -2,14 +2,16 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using System;
 
 namespace SchedulerBot.Database.Core.Migrations
 {
 	[DbContext(typeof(SchedulerBotContext))]
-	partial class SchedulerBotContextModelSnapshot : ModelSnapshot
+	[Migration("20180420113221_OccurrenceTypo")]
+	partial class OccurrenceTypo
 	{
-		protected override void BuildModel(ModelBuilder modelBuilder)
+		protected override void BuildTargetModel(ModelBuilder modelBuilder)
 		{
 #pragma warning disable 612, 618
 			modelBuilder

--- a/SchedulerBot/SchedulerBot.Database.Core/Migrations/20180420113221_OccurrenceTypo.cs
+++ b/SchedulerBot/SchedulerBot.Database.Core/Migrations/20180420113221_OccurrenceTypo.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace SchedulerBot.Database.Core.Migrations
+{
+	public partial class OccurrenceTypo : Migration
+	{
+		protected override void Up(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.RenameColumn(
+				name: "NextOccurence",
+				table: "ScheduledMessageEvents",
+				newName: "NextOccurrence");
+		}
+
+		protected override void Down(MigrationBuilder migrationBuilder)
+		{
+			migrationBuilder.RenameColumn(
+				name: "NextOccurrence",
+				table: "ScheduledMessageEvents",
+				newName: "NextOccurence");
+		}
+	}
+}

--- a/SchedulerBot/SchedulerBot.Database.Entities/ScheduledMessageEvent.cs
+++ b/SchedulerBot/SchedulerBot.Database.Entities/ScheduledMessageEvent.cs
@@ -5,7 +5,7 @@ using SchedulerBot.Database.Entities.Interfaces;
 namespace SchedulerBot.Database.Entities
 {
 	/// <summary>
-	/// Represents a single occurence of the scheduled message.
+	/// Represents a single occurrence of the scheduled message.
 	/// </summary>
 	public class ScheduledMessageEvent : ICreatedOn
 	{
@@ -20,9 +20,9 @@ namespace SchedulerBot.Database.Entities
 		public DateTime CreatedOn { get; set; }
 
 		/// <summary>
-		/// Gets or sets the next event occurence.
+		/// Gets or sets the next event occurrence.
 		/// </summary>
-		public DateTime NextOccurence { get; set; }
+		public DateTime NextOccurrence { get; set; }
 
 		/// <summary>
 		/// Gets or sets the event state.

--- a/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Schedule/ISchedule.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Schedule/ISchedule.cs
@@ -17,14 +17,14 @@ namespace SchedulerBot.Infrastructure.Interfaces.Schedule
 		/// Gets the next event occurrence.
 		/// </summary>
 		/// <returns>The time of the next event occurrence.</returns>
-		DateTime GetNextOccurence();
+		DateTime GetNextOccurrence();
 
 		/// <summary>
 		/// Gets the next event occurrence relatively to the specified time.
 		/// </summary>
 		/// <param name="baseTime">The base time.</param>
 		/// <returns>The time of the next event occurrence.</returns>
-		DateTime GetNextOccurence(DateTime baseTime);
+		DateTime GetNextOccurrence(DateTime baseTime);
 
 		/// <summary>
 		/// Gets the next event occurrences between the specified base and end time.
@@ -32,6 +32,6 @@ namespace SchedulerBot.Infrastructure.Interfaces.Schedule
 		/// <param name="baseTime">The base time.</param>
 		/// <param name="endTime">The end time.</param>
 		/// <returns>A set of the next event occurrences.</returns>
-		IEnumerable<DateTime> GetNextOccurences(DateTime baseTime, DateTime endTime);
+		IEnumerable<DateTime> GetNextOccurrences(DateTime baseTime, DateTime endTime);
 	}
 }

--- a/SchedulerBot/SchedulerBot.Infrastructure.Schedule/CronSchedule.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Schedule/CronSchedule.cs
@@ -34,27 +34,27 @@ namespace SchedulerBot.Infrastructure.Schedule
 		public string Text { get; }
 
 		/// <inheritdoc />
-		public DateTime GetNextOccurence() => GetNextOccurence(DateTime.UtcNow);
+		public DateTime GetNextOccurrence() => GetNextOccurrence(DateTime.UtcNow);
 
 		/// <inheritdoc />
-		public DateTime GetNextOccurence(DateTime baseTime)
+		public DateTime GetNextOccurrence(DateTime baseTime)
 		{
 			DateTime adjustedBaseTime = AdjustDateTime(baseTime);
-			DateTime nextOccurence = crontabSchedule.GetNextOccurrence(adjustedBaseTime);
-			DateTime adjustedNextOccurence = AdjustOccurence(nextOccurence);
+			DateTime nextOccurrence = crontabSchedule.GetNextOccurrence(adjustedBaseTime);
+			DateTime adjustedNextOccurrence = AdjustOccurrence(nextOccurrence);
 			
-			return adjustedNextOccurence;
+			return adjustedNextOccurrence;
 		}
 
 		/// <inheritdoc />
-		public IEnumerable<DateTime> GetNextOccurences(DateTime baseTime, DateTime endTime)
+		public IEnumerable<DateTime> GetNextOccurrences(DateTime baseTime, DateTime endTime)
 		{
 			DateTime adjustedBaseTime = AdjustDateTime(baseTime);
 			DateTime adjustedEndTime = AdjustDateTime(endTime);
 
 			return crontabSchedule
 				.GetNextOccurrences(adjustedBaseTime, adjustedEndTime)
-				.Select(AdjustOccurence);
+				.Select(AdjustOccurrence);
 		}
 
 		private DateTime AdjustDateTime(DateTime baseTime)
@@ -63,10 +63,10 @@ namespace SchedulerBot.Infrastructure.Schedule
 			return timeZoneOffset.HasValue && baseTime != DateTime.MaxValue ? baseTime.Add(timeZoneOffset.Value) : baseTime;
 		}
 
-		private DateTime AdjustOccurence(DateTime occurence)
+		private DateTime AdjustOccurrence(DateTime occurrence)
 		{
-			// if channel timeZoneOffset provided use it during calculation of nextOccurence in Utc
-			return timeZoneOffset.HasValue && occurence != DateTime.MinValue ? occurence.Add(-timeZoneOffset.Value) : occurence;
+			// if channel timeZoneOffset provided use it during calculation of nextOccurrence in Utc
+			return timeZoneOffset.HasValue && occurrence != DateTime.MinValue ? occurrence.Add(-timeZoneOffset.Value) : occurrence;
 		}
 	}
 }


### PR DESCRIPTION
Correct all usages across the code.
Add a migration to correct the typo in the database column name.

#22 