### PR TITLE
Strongly-typed configuration classes

### DIFF
--- a/SchedulerBot/SchedulerBot.Business.Commands/ManageCommand.cs
+++ b/SchedulerBot/SchedulerBot.Business.Commands/ManageCommand.cs
@@ -1,13 +1,12 @@
 ﻿using System;
-using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using SchedulerBot.Business.Entities;
 using SchedulerBot.Database.Core;
 using SchedulerBot.Database.Entities;
 using SchedulerBot.Infrastructure.Interfaces.Application;
+using SchedulerBot.Infrastructure.Interfaces.Configuration;
 using SchedulerBot.Infrastructure.Interfaces.Utils;
 
 namespace SchedulerBot.Business.Commands
@@ -43,15 +42,15 @@ namespace SchedulerBot.Business.Commands
 			SchedulerBotContext context,
 			IWebUtility webUtility,
 			IApplicationContext applicationContext,
-			IConfiguration configuration,
+			IManageCommandConfiguration configuration,
 			ILogger<ManageCommand> logger) : base("manage", logger)
 		{
 			this.context = context;
 			this.webUtility = webUtility;
 			this.applicationContext = applicationContext;
 
-			linkExpirationPeriod = TimeSpan.Parse(configuration["Commands:Manage:LinkExpirationPeriod"], CultureInfo.InvariantCulture);
-			linkIdLength = int.Parse(configuration["Commands:Manage:LinkIdLength"], CultureInfo.InvariantCulture);
+			linkExpirationPeriod = configuration.LinkExpirationPeriod;
+			linkIdLength = configuration.LinkIdLength;
 		}
 
 		#endregion

--- a/SchedulerBot/SchedulerBot.Business.Commands/NextCommand.cs
+++ b/SchedulerBot/SchedulerBot.Business.Commands/NextCommand.cs
@@ -6,7 +6,6 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using SchedulerBot.Business.Commands.Utils;
 using SchedulerBot.Business.Entities;
@@ -14,6 +13,7 @@ using SchedulerBot.Business.Utils;
 using SchedulerBot.Database.Core;
 using SchedulerBot.Database.Entities;
 using SchedulerBot.Database.Entities.Enums;
+using SchedulerBot.Infrastructure.Interfaces.Configuration;
 using SchedulerBot.Infrastructure.Interfaces.Schedule;
 
 namespace SchedulerBot.Business.Commands
@@ -45,14 +45,14 @@ namespace SchedulerBot.Business.Commands
 		public NextCommand(
 			SchedulerBotContext context,
 			IScheduleParser scheduleParser,
-			IConfiguration configuration,
+			INextCommandConfiguration configuration,
 			ILogger<ListCommand> logger) : base("next", logger)
 		{
 			this.context = context;
 			this.scheduleParser = scheduleParser;
 
-			defaultMessageCount = int.Parse(configuration["Commands:Next:DefaultMessageCount"], CultureInfo.InvariantCulture);
-			maxMessageCount = int.Parse(configuration["Commands:Next:MaxMessageCount"], CultureInfo.InvariantCulture);
+			defaultMessageCount = configuration.DefaultMessageCount;
+			maxMessageCount = configuration.MaxMessageCount;
 		}
 
 		#endregion

--- a/SchedulerBot/SchedulerBot.Business.Services/ScheduledMessageProcessorService.cs
+++ b/SchedulerBot/SchedulerBot.Business.Services/ScheduledMessageProcessorService.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Schema;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -15,6 +13,7 @@ using SchedulerBot.Database.Core;
 using SchedulerBot.Database.Entities;
 using SchedulerBot.Database.Entities.Enums;
 using SchedulerBot.Infrastructure.Interfaces.BotConnector;
+using SchedulerBot.Infrastructure.Interfaces.Configuration;
 using SchedulerBot.Infrastructure.Interfaces.Schedule;
 
 namespace SchedulerBot.Business.Services
@@ -51,7 +50,7 @@ namespace SchedulerBot.Business.Services
 		public ScheduledMessageProcessorService(
 			IScheduleParser scheduleParser,
 			IServiceScopeFactory scopeFactory,
-			IConfiguration configuration,
+			IApplicationConfiguration configuration,
 			ILogger<ScheduledMessageProcessorService> logger,
 			IMessageProcessor messageProcessor)
 		{
@@ -60,7 +59,7 @@ namespace SchedulerBot.Business.Services
 			this.logger = logger;
 			this.messageProcessor = messageProcessor;
 
-			pollingInterval = TimeSpan.Parse(configuration["MessageProcessingInterval"], CultureInfo.InvariantCulture);
+			pollingInterval = configuration.MessageProcessingInterval;
 			serviceCancellationTokenSource = new CancellationTokenSource();
 			serviceCancellationToken = serviceCancellationTokenSource.Token;
 		}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/ApplicationConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/ApplicationConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using SchedulerBot.Infrastructure.Interfaces.Configuration;
+
+namespace SchedulerBot.Infrastructure.Application.Configuration
+{
+	public class ApplicationConfiguration : IApplicationConfiguration
+	{
+		public ApplicationConfiguration(
+			ISecretConfiguration secrets,
+			ICommandConfiguration commands)
+		{
+			Secrets = secrets;
+			Commands = commands;
+		}
+
+		public TimeSpan MessageProcessingInterval { get; set; }
+
+		public string ConnectionString { get; set; }
+
+		public ISecretConfiguration Secrets { get; }
+
+		public ICommandConfiguration Commands { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/AuthenticationConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/AuthenticationConfiguration.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using SchedulerBot.Infrastructure.Interfaces.Configuration;
+
+namespace SchedulerBot.Infrastructure.Application.Configuration
+{
+	public class AuthenticationConfiguration : IAuthenticationConfiguration
+	{
+		public string Scheme { get; set; }
+
+		public string SigningKey { get; set; }
+
+		public string Issuer { get; set; }
+
+		public string Audience { get; set; }
+
+		public TimeSpan ExpirationPeriod { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/CommandConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/CommandConfiguration.cs
@@ -1,0 +1,19 @@
+﻿using SchedulerBot.Infrastructure.Interfaces.Configuration;
+
+namespace SchedulerBot.Infrastructure.Application.Configuration
+{
+	public class CommandConfiguration : ICommandConfiguration
+	{
+		public CommandConfiguration(
+			IManageCommandConfiguration manage,
+			INextCommandConfiguration next)
+		{
+			Manage = manage;
+			Next = next;
+		}
+
+		public IManageCommandConfiguration Manage { get; set; }
+
+		public INextCommandConfiguration Next { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/ManageCommandConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/ManageCommandConfiguration.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using SchedulerBot.Infrastructure.Interfaces.Configuration;
+
+namespace SchedulerBot.Infrastructure.Application.Configuration
+{
+	public class ManageCommandConfiguration : IManageCommandConfiguration
+	{
+		public TimeSpan LinkExpirationPeriod { get; set; }
+
+		public int LinkIdLength { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/NextCommandConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/NextCommandConfiguration.cs
@@ -1,0 +1,11 @@
+﻿using SchedulerBot.Infrastructure.Interfaces.Configuration;
+
+namespace SchedulerBot.Infrastructure.Application.Configuration
+{
+	public class NextCommandConfiguration : INextCommandConfiguration
+	{
+		public int MaxMessageCount { get; set; }
+
+		public int DefaultMessageCount { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/SecretConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Application/Configuration/SecretConfiguration.cs
@@ -1,0 +1,20 @@
+﻿using SchedulerBot.Infrastructure.Interfaces.Configuration;
+
+namespace SchedulerBot.Infrastructure.Application.Configuration
+{
+	public class SecretConfiguration : ISecretConfiguration
+	{
+		public SecretConfiguration(IAuthenticationConfiguration authentication)
+		{
+			Authentication = authentication;
+		}
+
+		public string ConnectionString { get; set; }
+
+		public string MicrosoftAppId { get; set; }
+
+		public string MicrosoftAppPassword { get; set; }
+
+		public IAuthenticationConfiguration Authentication { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Authentication/SchedulerBot.Infrastructure.Authentication.csproj
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Authentication/SchedulerBot.Infrastructure.Authentication.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.1.0-rc1-final" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\SchedulerBot.Infrastructure.Interfaces\SchedulerBot.Infrastructure.Interfaces.csproj" />
   </ItemGroup>
 

--- a/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/IApplicationConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/IApplicationConfiguration.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace SchedulerBot.Infrastructure.Interfaces.Configuration
+{
+	public interface IApplicationConfiguration
+	{
+		TimeSpan MessageProcessingInterval { get; set; }
+
+		string ConnectionString { get; set; }
+
+		ISecretConfiguration Secrets { get; }
+
+		ICommandConfiguration Commands { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/IAuthenticationConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/IAuthenticationConfiguration.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace SchedulerBot.Infrastructure.Interfaces.Configuration
+{
+	public interface IAuthenticationConfiguration
+	{
+		string Scheme { get; set; }
+
+		string SigningKey { get; set; }
+
+		string Issuer { get; set; }
+
+		string Audience { get; set; }
+
+		TimeSpan ExpirationPeriod { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/ICommandConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/ICommandConfiguration.cs
@@ -1,0 +1,9 @@
+﻿namespace SchedulerBot.Infrastructure.Interfaces.Configuration
+{
+	public interface ICommandConfiguration
+	{
+		IManageCommandConfiguration Manage { get; set; }
+
+		INextCommandConfiguration Next { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/IManageCommandConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/IManageCommandConfiguration.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace SchedulerBot.Infrastructure.Interfaces.Configuration
+{
+	public interface IManageCommandConfiguration
+	{
+		TimeSpan LinkExpirationPeriod { get; set; }
+
+		int LinkIdLength { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/INextCommandConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/INextCommandConfiguration.cs
@@ -1,0 +1,9 @@
+﻿namespace SchedulerBot.Infrastructure.Interfaces.Configuration
+{
+	public interface INextCommandConfiguration
+	{
+		int MaxMessageCount { get; set; }
+
+		int DefaultMessageCount { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/ISecretConfiguration.cs
+++ b/SchedulerBot/SchedulerBot.Infrastructure.Interfaces/Configuration/ISecretConfiguration.cs
@@ -1,0 +1,13 @@
+﻿namespace SchedulerBot.Infrastructure.Interfaces.Configuration
+{
+	public interface ISecretConfiguration
+	{
+		string ConnectionString { get; set; }
+
+		string MicrosoftAppId { get; set; }
+
+		string MicrosoftAppPassword { get; set; }
+
+		IAuthenticationConfiguration Authentication { get; set; }
+	}
+}

--- a/SchedulerBot/SchedulerBot/Extensions/ConfigurationExtensions.cs
+++ b/SchedulerBot/SchedulerBot/Extensions/ConfigurationExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using SchedulerBot.Authentication;
 using SchedulerBot.Database.Core;
+using SchedulerBot.Infrastructure.Interfaces.Configuration;
 
 namespace SchedulerBot.Extensions
 {
@@ -60,19 +61,6 @@ namespace SchedulerBot.Extensions
 		}
 
 		/// <summary>
-		/// Gets the connection string from the specified configuration.
-		/// </summary>
-		/// <param name="configuration">The configuration.</param>
-		/// <returns>The connection string</returns>
-		public static string GetConnectionString(this IConfiguration configuration)
-		{
-			string settingName = IsDevelopment() ? "ConnectionString" : "Secrets:ConnectionString";
-			string connectionString = configuration[settingName];
-
-			return connectionString;
-		}
-
-		/// <summary>
 		/// Configures the authentication scheme used for managing conversations.
 		/// </summary>
 		/// <param name="builder">The builder.</param>
@@ -83,7 +71,7 @@ namespace SchedulerBot.Extensions
 		/// </returns>
 		public static AuthenticationBuilder AddManageConversationAuthentication(
 			this AuthenticationBuilder builder,
-			IConfiguration configuration)
+			IAuthenticationConfiguration configuration)
 		{
 			return builder
 				.AddJwtBearer(
@@ -101,7 +89,7 @@ namespace SchedulerBot.Extensions
 			return EnvironmentName.Development.Equals(currentEnvironmentName, StringComparison.Ordinal);
 		}
 
-		private static void ConfigureJwtValidation(JwtBearerOptions options, IConfiguration configuration)
+		private static void ConfigureJwtValidation(JwtBearerOptions options, IAuthenticationConfiguration configuration)
 		{
 			TokenValidationParameters validationParameters = options.TokenValidationParameters;
 
@@ -111,9 +99,9 @@ namespace SchedulerBot.Extensions
 			validationParameters.ValidateLifetime = true;
 			validationParameters.RequireSignedTokens = true;
 			validationParameters.RequireExpirationTime = true;
-			validationParameters.IssuerSigningKey = new SymmetricSecurityKey(Convert.FromBase64String(configuration["Secrets:Authentication:0:SigningKey"]));
-			validationParameters.ValidAudience = configuration["Secrets:Authentication:0:Audience"];
-			validationParameters.ValidIssuer = configuration["Secrets:Authentication:0:Issuer"];
+			validationParameters.IssuerSigningKey = new SymmetricSecurityKey(Convert.FromBase64String(configuration.SigningKey));
+			validationParameters.ValidAudience = configuration.Audience;
+			validationParameters.ValidIssuer = configuration.Issuer;
 		}
 	}
 }

--- a/SchedulerBot/SchedulerBot/appsettings.json
+++ b/SchedulerBot/SchedulerBot/appsettings.json
@@ -1,7 +1,5 @@
 ﻿{
 	"MessageProcessingInterval": "0.00:00:20",
-	"ConnectionString_NotUsed": "Data Source=(local);Initial Catalog=SchedulerBot;Integrated Security=SSPI;",
-	"ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=SchedulerBot;Trusted_Connection=True;",
 	"Logging": {
 		"IncludeScopes": false,
 		"Debug": {
@@ -16,17 +14,17 @@
 		}
 	},
 	"Secrets": {
-		"MicrosoftAppIdKey": "",
-		"MicrosoftAppPassword": "",
-		"Authentication": [
-			{
-				"Scheme": "Manage",
-				"SigningKey": "TLErwc5T7oF6i4qtQWoi7UMMxqQZRjf3gxn9jhghoa+TXnVLBZ39+8i4JJGXcHV22pUppRgchU/wu6oEIE6vyQ==",
-				"Issuer": "scheduler-bot",
-				"Audience": "scheduler-bot",
-				"ExpirationPeriod": "0.00:10:00"
-			}
-		]
+		"MicrosoftAppId": "1",
+		"MicrosoftAppPassword": "2",
+		"ConnectionString_NotUsed": "Data Source=(local);Initial Catalog=SchedulerBot;Integrated Security=SSPI;",
+		"ConnectionString": "Server=(localdb)\\mssqllocaldb;Database=SchedulerBot;Trusted_Connection=True;",
+		"Authentication": {
+			"Scheme": "Manage",
+			"SigningKey": "TLErwc5T7oF6i4qtQWoi7UMMxqQZRjf3gxn9jhghoa+TXnVLBZ39+8i4JJGXcHV22pUppRgchU/wu6oEIE6vyQ==",
+			"Issuer": "scheduler-bot",
+			"Audience": "scheduler-bot",
+			"ExpirationPeriod": "0.00:10:00"
+		}
 	},
 	"Commands": {
 		"Next": {


### PR DESCRIPTION
Add strongly typed configuration classes mapped to the json config and use them instead of IConfiguration.