### PR TITLE
Fix next command crash if no culture is being passed

### DIFF
--- a/SchedulerBot/SchedulerBot.Business.Commands/NextCommand.cs
+++ b/SchedulerBot/SchedulerBot.Business.Commands/NextCommand.cs
@@ -62,7 +62,7 @@ namespace SchedulerBot.Business.Commands
 		/// <inheritdoc />
 		protected override Task<CommandExecutionResult> ExecuteCoreAsync(Activity activity, string arguments)
 		{
-			CultureInfo clientCulture = GetCultureInfoOrDefault(activity.Locale);
+			CultureInfo clientCulture = CultureUtils.GetCultureInfoOrDefault(activity.Locale);
 			CommandExecutionResult result = string.IsNullOrWhiteSpace(arguments)
 				? ExecuteWithNoArguments(activity, clientCulture)
 				: ExecuteWithArguments(activity, arguments, clientCulture);
@@ -248,22 +248,6 @@ namespace SchedulerBot.Business.Commands
 		private static CommandExecutionResult GetNoScheduledMessagesResult()
 		{
 			return CommandExecutionResult.Success("No scheduled events for this conversation");
-		}
-
-		private static CultureInfo GetCultureInfoOrDefault(string name)
-		{
-			CultureInfo cultureInfo;
-
-			try
-			{
-				cultureInfo = CultureInfo.GetCultureInfo(name);
-			}
-			catch (CultureNotFoundException)
-			{
-				cultureInfo = CultureInfo.InvariantCulture;
-			}
-
-			return cultureInfo;
 		}
 
 		#endregion

--- a/SchedulerBot/SchedulerBot.Business.Utils/CultureUtils.cs
+++ b/SchedulerBot/SchedulerBot.Business.Utils/CultureUtils.cs
@@ -1,0 +1,40 @@
+﻿using System.Globalization;
+
+namespace SchedulerBot.Business.Utils
+{
+	/// <summary>
+	/// Provides utility methods for working with culture and localization.
+	/// </summary>
+	public static class CultureUtils
+	{
+		private static readonly CultureInfo DefaultCultureInfo = CultureInfo.GetCultureInfo("en-US");
+
+		/// <summary>
+		/// Gets the culture information by the specified name or returns the default culture if nothing is found by the name.
+		/// </summary>
+		/// <param name="name">The culture name (e.g. en-US).</param>
+		/// <returns>The <see cref="CultureInfo"/> instance found by the name or the default culture.</returns>
+		public static CultureInfo GetCultureInfoOrDefault(string name)
+		{
+			CultureInfo cultureInfo;
+
+			if (string.IsNullOrWhiteSpace(name))
+			{
+				cultureInfo = DefaultCultureInfo;
+			}
+			else
+			{
+				try
+				{
+					cultureInfo = CultureInfo.GetCultureInfo(name);
+				}
+				catch (CultureNotFoundException)
+				{
+					cultureInfo = DefaultCultureInfo;
+				}
+			}
+
+			return cultureInfo;
+		}
+	}
+}


### PR DESCRIPTION
Create a helper for getting a culture in the next command and make it work with a null culture name.

#35 